### PR TITLE
Pass no-login as a command line argument when used within a openshift

### DIFF
--- a/packages/ecflow_openshift_agent/agent.py
+++ b/packages/ecflow_openshift_agent/agent.py
@@ -120,26 +120,32 @@ class Agent:
         token=None,
         token_from_env_key=None,
         log_level=logging.INFO,
+        no_login=False,
     ):
         self.project = project
         self.api_server_url = api_server_url
         self.kubeconfig = set_kubeconfig()
 
-        with oc.api_server(self.api_server_url), oc.project(self.project):
-            if username is not None and password is not None:
-                oc.login(username, password)
-            else:
-                self.token = None
-                if token is not None:
-                    self.token = token
-                elif token_from_env_key is not None:
-                    self.token = os.environ[token_from_env_key]
+        if no_login:
+            logging.info(f"Agent is run from within the OpenShift environment, so no login is required.")
+            logging.info(f"Logged in as {oc.whoami()}")
+            logging.info(f"Current project: {oc.get_project_name()}")
+        else:
+            with oc.api_server(self.api_server_url), oc.project(self.project):
+                if username is not None and password is not None:
+                    oc.login(username, password)
+                else:
+                    self.token = None
+                    if token is not None:
+                        self.token = token
+                    elif token_from_env_key is not None:
+                        self.token = os.environ[token_from_env_key]
 
-                assert (
-                    self.token is not None
-                ), "No login credentials given, either username/password or token is required"
+                    assert (
+                        self.token is not None
+                    ), "No login credentials given, either username/password or token is required"
 
-                self.login_with_token(self.token)
+                    self.login_with_token(self.token)
 
             logging.info(f"Logged in as {oc.whoami()}")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+openshift-client==1.0.23

--- a/run-agent.py
+++ b/run-agent.py
@@ -44,22 +44,26 @@ def parse_args():
         help="command: create_job_from_template",
     )
     parser.add_argument(
+        "--no-login",
+        action='store_true',
+    )
+    parser.add_argument(
         "--token-from-env-key",
         type=str,
-        required=True,
+        required=False if "--no-login" in sys.argv else True,
         default="ECFLOW_OPENSHIFT_TOKEN",
         help="token from env: ECFLOW_OPENSHIFT_TOKEN",
     )
     parser.add_argument(
         "--api-server-url",
         type=str,
-        required=True,
+        required=False if "--no-login" in sys.argv else True,
         help="api server url: https://api.openshift.com",
     )
     parser.add_argument(
         "--project",
         type=str,
-        required=True,
+        required=False if "--no-login" in sys.argv else True,
         help="openshift project (namespace)",
     )
     parser.add_argument(
@@ -99,6 +103,7 @@ agent = Agent(
     project=args.project,
     token_from_env_key=args.token_from_env_key,
     log_level=args.log_level,
+    no_login=args.no_login
 )
 
 if args.command == "create-job-from-template":


### PR DESCRIPTION
There is no need to login to a cluster if the agent is run within a openshift environment. Pass --no-login as a command line argument to skip the unwanted login, so there's no need to create and manage the authentication token.